### PR TITLE
Added default parameter to square-psuedo mixin

### DIFF
--- a/scss/mixins/square-pseudo.scss
+++ b/scss/mixins/square-pseudo.scss
@@ -1,4 +1,4 @@
-@mixin square-pseudo($pseudo: before, $square-size) {
+@mixin square-pseudo($pseudo: before, $square-size: 0) {
 
     width: $square-size;
 


### PR DESCRIPTION
Some versions of SaSS seem to complain if there is an optional parameter before a required one